### PR TITLE
lspci: Remove obsolete buildPath function

### DIFF
--- a/cmd/lspci/README.md
+++ b/cmd/lspci/README.md
@@ -32,12 +32,15 @@ Options:
   -veryverbose
     	Be very verbose
   -vv
+
+  -xml
+        use XML output format
 ```
 
 ## Example
 
 ```shell
-# ./lspci -nn -v
+# lspci -nn -v
 00:00.0 Host bridge [0600]: Intel Corporation 440FX - 82441FX PMC [Natoma] [8086:1237] (rev 02)
 00:01.0 ISA bridge [0601]: Intel Corporation 82371SB PIIX3 ISA [Natoma/Triton II] [8086:7000]
 00:01.1 IDE interface [0101]: Intel Corporation 82371AB/EB/MB PIIX4 IDE [8086:7111] (rev 01)
@@ -51,4 +54,51 @@ Options:
         Kernel driver in use: vboxguest
 00:07.0 Bridge [0680]: Intel Corporation 82371AB/EB/MB PIIX4 ACPI [8086:7113] (rev 08)
         Kernel driver in use: piix4_smbus
+```
+
+json output
+```
+$ lspci -j
+{
+    "pcidevices": [
+        {
+            "Bus": "0000:00:00.0",
+            "VendorID": "8086",
+            "DeviceID": "1237",
+            "Class": "0600",
+            "SubsysVendor": "0000",
+            "SubsysDevice": "0000",
+            "Irq": "0",
+            "Revision": "02",
+            "VendorName": "Intel Corporation",
+            "DeviceName": "440FX - 82441FX PMC [Natoma]",
+            "DeviceClass": "Host bridge",
+            "Subsystem": "",
+            "KernelModule": "",
+            "KernelModuleAlias": "pci:v00008086d00001237sv00000000sd00000000bc06sc00i00",
+            "KernelDriver": ""
+        },
+...
+```
+
+xml output
+```
+$ ./lspci -xml
+<PciDevice>
+    <Bus>00:00.0</Bus>
+    <VendorID>8086</VendorID>
+    <DeviceID>1237</DeviceID>
+    <Class>0600</Class>
+    <SubsysVendor>0000</SubsysVendor>
+    <SubsysDevice>0000</SubsysDevice>
+    <Irq>0</Irq>
+    <Revision>02</Revision>
+    <VendorName>Intel Corporation</VendorName>
+    <DeviceName>440FX - 82441FX PMC [Natoma]</DeviceName>
+    <DeviceClass>Host bridge</DeviceClass>
+    <Subsystem></Subsystem>
+    <KernelModule></KernelModule>
+    <KernelModuleAlias>pci:v00008086d00001237sv00000000sd00000000bc06sc00i00</KernelModuleAlias>
+    <KernelDriver></KernelDriver>
+</PciDevice>
 ```

--- a/cmd/lspci/lspci.go
+++ b/cmd/lspci/lspci.go
@@ -236,20 +236,12 @@ func Lookup(searchType, ven, dev, class, subclass string) string {
 func ParsePciDevices() []PciDevice {
 	var devices []string
 
-	buildPath := func(items ...string) string {
-		var path string
-		for _, item := range items {
-			path += item + "/"
-		}
-		return strings.TrimSuffix(path, "/")
-	}
-
 	read := func(bus, filename string) string {
-		return readFromFile(buildPath(PATH_SYS_BUS_PCI_DEVICES, bus, filename), 1)
+		return readFromFile(filepath.Join(PATH_SYS_BUS_PCI_DEVICES, bus, filename), 1)
 	}
 
 	lookupKernelDriver := func(bus string) string {
-		read := readFromFile(buildPath(PATH_SYS_DEVICES_PCI+bus[0:7], bus, "uevent"), 1)
+		read := readFromFile(filepath.Join(PATH_SYS_DEVICES_PCI+bus[0:7], bus, "uevent"), 1)
 		if strings.Contains(read, "DRIVER=") {
 			return read[7:]
 		}


### PR DESCRIPTION
and update examples in README.md